### PR TITLE
Fix crash on not command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+# v1.0.3
+- Fixed issue with unmapped commands not being properly handled by `GetCommandMapping`
+  - Was improperly assuming the default value of a string, doing a proper null check now
+
 # v1.0.2
 - Added example Data Directory to publish
 - Fixed even more issues with redirect, this time with string concatenation

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # v1.0.3
 - Fixed issue with unmapped commands not being properly handled by `GetCommandMapping`
   - Was improperly assuming the default value of a string, doing a proper null check now
+- Added some error handling around the command handler so that commands don't necessarily crash the bot
+  - Mistakenly thought that errors would bubble up to `Program` but will probably have to do some better handling of errors within each event if it makes sense
 
 # v1.0.2
 - Added example Data Directory to publish

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 MIT License
 
-Copyright (c) 2023 Metarract
+Copyright (c) 2024 Metarract
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Src/Bot.cs
+++ b/Src/Bot.cs
@@ -97,8 +97,14 @@ public sealed class Bot {
   }
 
   private async void OnClientCommandReceived (object? sender, OnChatCommandReceivedArgs e) {
-    var response = await MessageHandler.GetCommandResponse(e.Command, config.CommandConfig);
-    if (response != null) Client.SendMessage(e.Command.ChatMessage.Channel, response);
+    try {
+      var response = await MessageHandler.GetCommandResponse(e.Command, config.CommandConfig);
+      if (response != null) Client.SendMessage(e.Command.ChatMessage.Channel, response);
+    } catch (Exception err) {
+      Log.Error("Error received while processing commands");
+      Log.Error(err.Message);
+      if (err.StackTrace is not null) Log.Error($"Trace:\r\n{err.StackTrace}");
+    }
   }
   #endregion
 }

--- a/Src/MessageHandler.cs
+++ b/Src/MessageHandler.cs
@@ -26,8 +26,7 @@ public static class MessageHandler {
 
   private static string GetCommandMapping (string command, List<CommandMap> mappings) {
     var match = mappings.Find(mapping => mapping.Input.ToLower().Trim() == command.ToLower().Trim());
-    if (match.Target.Trim().Length != 0) return match.Target.ToLower().Trim();
-    return command.ToLower().Trim();
+    return ((match.Target?.Trim() is not null) ? match.Target : command).ToLower().Trim();
   }
 
   public async static Task<string?> GetCommandResponse (ChatCommand command, CommandConfig commandConfig) {


### PR DESCRIPTION
due to assumptions i had about what the default value of a string was, unmapped commands not found by `GetCommandMapping` would cause null ref exceptions

i have fixed this assumption and now `GetCommandMapping` properly checks if the string is `null` (and if the trimmed string is `null`)

also a little error handling for the command listener